### PR TITLE
Update SCM info in the POM file for release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,9 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:https://github.com/chef/chef-jenkins-plugin.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/chef/chef-jenkins-plugin.git</developerConnection>
+		<connection>scm:git:ssh://github.com/jenkinsci/chef-cookbook-pipeline-plugin.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/chef-cookbook-pipeline-plugin.git</developerConnection>
+		<url>https://github.com/jenkinsci/chef-cookbook-pipeline-plugin</url>
 		<tag>HEAD</tag>
 	</scm>
 


### PR DESCRIPTION
This updates the POM file to use the jenkinsci as the release repo per the Jenkins plugin hosting documentation, and preps the POM to support releasing v0.1.0.

/cc @jonsmorrow @prajaktapurohit @nsdavidson